### PR TITLE
팀 스페이스 crud 기능 추가

### DIFF
--- a/AuthContext.tsx
+++ b/AuthContext.tsx
@@ -22,6 +22,7 @@ interface AuthContextType {
   deleteWorkspace: (id: string) => Promise<boolean>;
   kickMember: (workspaceId: string, memberId: string) => Promise<boolean>;
   banMember: (workspaceId: string, memberId: string) => Promise<boolean>;
+  unbanMember: (workspaceId: string, memberId: string) => Promise<boolean>;
 
   refreshWorkspaces: () => Promise<void>;
   
@@ -398,6 +399,23 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
   }, [_currentWorkspace, refreshWorkspaces]);
 
+  // 멤버 차단 해제
+  const unbanMember = useCallback(async (workspaceId: string, memberId: string): Promise<boolean> => {
+    setLoading(true);
+    setError(null);
+    try {
+      await workspaceApi.unbanMember(workspaceId, memberId);
+      await refreshWorkspaces();
+      return true;
+    } catch (err) {
+      const errorMessage = err instanceof ApiError ? err.message : '멤버 차단 해제에 실패했습니다.';
+      setError(errorMessage);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [refreshWorkspaces]);
+
   // 새 초대링크 생성 기능은 제거됨 - 워크스페이스 ID 기반 고정 링크 사용
 
   // 초기 로드 시 첫 번째 워크스페이스 설정 또는 빈 워크스페이스 페이지로 이동
@@ -523,6 +541,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         deleteWorkspace,
         kickMember,
         banMember,
+        unbanMember,
         refreshWorkspaces,
         
         chatRooms: filteredChatRooms, 

--- a/components/modals/TeamActionModal.tsx
+++ b/components/modals/TeamActionModal.tsx
@@ -1,42 +1,131 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Modal, Button } from '../ui';
 import { ArrowLeftIcon } from '../icons';
 import { ItemListSelector } from '../complex';
 import { TeamProject } from '../../types';
 import { useAuth } from '../../AuthContext';
+import { teamApi } from '../../services/api';
 
 interface TeamActionModalProps {
     isOpen: boolean;
     onClose: () => void;
+    initialStep?: 'teamAction' | 'createTeam' | 'joinList'; // 초기 단계 설정 prop 추가
 }
 
-const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose }) => {
-    const { currentWorkspace, setCurrentTeamProject } = useAuth();
+const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose, initialStep = 'teamAction' }) => {
+    const { currentWorkspace, setCurrentTeamProject, currentUser } = useAuth();
     const navigate = useNavigate();
-    const [step, setStep] = useState<'initial' | 'joinList'>('initial');
+    const [step, setStep] = useState<'teamAction' | 'createTeam' | 'joinList'>(initialStep);
     const [selectedTeamToJoin, setSelectedTeamToJoin] = useState<TeamProject | null>(null);
+    const [teams, setTeams] = useState<TeamProject[]>([]);
+    const [isLoadingTeams, setIsLoadingTeams] = useState(false);
+    
+    // 팀 생성 폼 상태
+    const [teamName, setTeamName] = useState('');
+    const [isCreatingTeam, setIsCreatingTeam] = useState(false);
 
     const availableTeamsToJoin = useMemo(() => {
-        if (!currentWorkspace) return [];
-        // 목업 데이터 제거 - 실제 API에서 팀 목록을 가져와야 함
-        return []; // MOCK_TEAM_PROJECTS_APP 대신 빈 배열
-    }, [currentWorkspace]);
+        if (!currentWorkspace || !currentUser) return [];
+        
+        // 현재 사용자가 이미 참여하지 않은 팀만 필터링
+        return teams.filter(team => {
+            // 팀 멤버 목록에서 현재 사용자가 있는지 확인
+            const isAlreadyMember = team.members?.some(member => 
+                member.id === currentUser.id || member.email === currentUser.email
+            );
+            return !isAlreadyMember;
+        });
+    }, [currentWorkspace, teams, currentUser]);
+
+    // 팀 목록 로드
+    const loadTeams = async () => {
+        if (!currentWorkspace || !isOpen) return;
+        
+        setIsLoadingTeams(true);
+        
+        try {
+            const teamList = await teamApi.getTeamsByWorkspace(currentWorkspace.id);
+            setTeams(teamList);
+        } catch (error: any) {
+            console.error('팀 목록 로드 실패:', error);
+            setTeams([]);
+        } finally {
+            setIsLoadingTeams(false);
+        }
+    };
+
+    // 모달이 열릴 때마다 팀 목록 로드하고 초기 step 설정
+    useEffect(() => {
+        if (isOpen && currentWorkspace) {
+            setStep(initialStep);
+            loadTeams();
+        }
+    }, [isOpen, currentWorkspace, initialStep]);
 
     const handleCloseAndReset = () => {
         onClose();
-        setStep('initial');
+        setStep(initialStep);
         setSelectedTeamToJoin(null);
+        setTeamName('');
     };
 
-    const handleJoinTeam = () => {
-        if (selectedTeamToJoin && currentWorkspace) {
-            alert(`${selectedTeamToJoin.name} 팀에 참여했습니다! (목업)`);
+    const handleCreateTeam = async () => {
+        if (!teamName.trim() || !currentWorkspace) {
+            alert("팀 이름을 입력해주세요.");
+            return;
+        }
+
+        try {
+            setIsCreatingTeam(true);
+            const newTeam = await teamApi.createTeam({
+                name: teamName.trim(),
+                workspaceId: currentWorkspace.id
+            });
+            alert(`${newTeam.name} 팀이 생성되었습니다!`);
+            setCurrentTeamProject(newTeam);
+            navigate(`/ws/${currentWorkspace.id}/team/${newTeam.id}`);
+            handleCloseAndReset();
+        } catch (error: any) {
+            console.error('팀 생성 실패:', error);
+            alert(error.response?.data?.detail || error.message || '팀 생성에 실패했습니다.');
+        } finally {
+            setIsCreatingTeam(false);
+        }
+    };
+
+    const handleJoinTeam = async () => {
+        if (!selectedTeamToJoin || !currentWorkspace) {
+            alert("팀을 선택해주세요 또는 워크스페이스 정보가 없습니다.");
+            return;
+        }
+
+        try {
+            await teamApi.joinTeam(selectedTeamToJoin.id);
+            alert(`${selectedTeamToJoin.name} 팀에 참여했습니다!`);
             setCurrentTeamProject(selectedTeamToJoin); // Set context for joined team
             navigate(`/ws/${currentWorkspace.id}/team/${selectedTeamToJoin.id}`);
             handleCloseAndReset();
-        } else {
-            alert("팀을 선택해주세요 또는 워크스페이스 정보가 없습니다.");
+        } catch (error: any) {
+            console.error('팀 참여 실패:', error);
+            
+            // 500 에러와 에러 메시지를 확인하여 적절한 메시지로 변환
+            if (error.response?.status === 500) {
+                const errorDetail = error.response?.data?.detail;
+                if (errorDetail && errorDetail.includes('이미 팀의 멤버입니다')) {
+                    alert('이미 참여된 팀입니다.');
+                    return;
+                }
+            }
+            
+            // 기타 에러 처리
+            if (error.response?.data?.detail) {
+                alert(error.response.data.detail);
+            } else if (error.message) {
+                alert(error.message);
+            } else {
+                alert('팀 참여에 실패했습니다.');
+            }
         }
     };
 
@@ -47,11 +136,12 @@ const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose }) =>
       </div>
     );
     
-    let modalTitle = "팀 생성 또는 참여";
+    let modalTitle = "팀 관리";
     let modalFooter;
     let modalContent;
 
-    if (step === 'initial') {
+    if (step === 'teamAction') {
+        modalTitle = "팀 생성 또는 참여";
         modalFooter = (
             <div className="flex justify-end space-x-2">
                 <Button variant="ghost" onClick={handleCloseAndReset}>취소</Button>
@@ -61,7 +151,7 @@ const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose }) =>
             <div className="space-y-3">
                 <Button 
                     className="w-full" 
-                    onClick={() => { navigate('/team-formation'); handleCloseAndReset(); }}
+                    onClick={() => setStep('createTeam')}
                 >
                     새 팀 만들기
                 </Button>
@@ -69,23 +159,69 @@ const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose }) =>
                     className="w-full" 
                     variant="outline" 
                     onClick={() => setStep('joinList')}
-                    disabled={!currentWorkspace || availableTeamsToJoin.length === 0}
+                    disabled={!currentWorkspace || isLoadingTeams || availableTeamsToJoin.length === 0}
                 >
-                    기존 팀 참여하기
+                    {isLoadingTeams ? '팀 목록 로딩 중...' : '기존 팀 참여하기'}
                 </Button>
-                {(!currentWorkspace || availableTeamsToJoin.length === 0) && (
+                {(!currentWorkspace || (availableTeamsToJoin.length === 0 && !isLoadingTeams)) && (
                     <p className="text-xs text-neutral-500 text-center">현재 워크스페이스에 참여할 수 있는 팀이 없습니다.</p>
                 )}
+            </div>
+        );
+    } else if (step === 'createTeam') {
+        modalTitle = "새 팀 만들기";
+        modalFooter = (
+            <div className="flex justify-between w-full">
+                <Button variant="ghost" onClick={() => setStep('teamAction')} leftIcon={<ArrowLeftIcon className="w-4 h-4"/>}>
+                    뒤로
+                </Button>
+                <div className="flex space-x-2">
+                    <Button variant="ghost" onClick={handleCloseAndReset}>취소</Button>
+                    <Button onClick={handleCreateTeam} disabled={!teamName.trim() || isCreatingTeam}>
+                        {isCreatingTeam ? '생성 중...' : '팀 생성'}
+                    </Button>
+                </div>
+            </div>
+        );
+        modalContent = (
+            <div className="space-y-4">
+                <div>
+                    <h3 className="text-lg font-medium text-neutral-900 mb-2">
+                        {currentWorkspace?.name} 워크스페이스에 새로운 팀을 만들어보세요.
+                    </h3>
+                </div>
+                
+                <div>
+                    <label className="block text-sm font-medium text-neutral-700 mb-2">
+                        팀 이름
+                    </label>
+                    <input
+                        type="text"
+                        value={teamName}
+                        onChange={(e) => setTeamName(e.target.value)}
+                        placeholder="예: 프론트엔드팀, 백엔드팀, 디자인팀"
+                        className="w-full px-3 py-2 border border-neutral-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+                        disabled={isCreatingTeam}
+                    />
+                </div>
+
+                <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
+                    <div className="text-sm text-blue-700 space-y-1">
+                        <p>• 팀을 생성하면 자동으로 팀장이 됩니다.</p>
+                        <p>• 워크스페이스의 다른 멤버들을 팀에 초대할 수 있습니다.</p>
+                        <p>• 팀만의 칸반 보드, 게시판, 일정 관리를 사용할 수 있습니다.</p>
+                    </div>
+                </div>
             </div>
         );
     } else { // step === 'joinList'
         modalTitle = "기존 팀에 참여하기";
         modalFooter = (
             <div className="flex justify-between w-full">
-                <Button variant="ghost" onClick={() => { setStep('initial'); setSelectedTeamToJoin(null); }} leftIcon={<ArrowLeftIcon className="w-4 h-4"/>}>
+                <Button variant="ghost" onClick={() => { setStep('teamAction'); setSelectedTeamToJoin(null); }} leftIcon={<ArrowLeftIcon className="w-4 h-4"/>}>
                     뒤로
                 </Button>
-                <div className="space-x-2">
+                <div className="flex space-x-2">
                     <Button variant="ghost" onClick={handleCloseAndReset}>취소</Button>
                     <Button onClick={handleJoinTeam} disabled={!selectedTeamToJoin}>참여하기</Button>
                 </div>
@@ -93,6 +229,12 @@ const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose }) =>
         );
         modalContent = (
             <div>
+                {isLoadingTeams ? (
+                    <div className="text-center py-4">팀 목록을 불러오는 중...</div>
+                ) : availableTeamsToJoin.length === 0 ? (
+                    <div className="text-center py-4 text-neutral-500">참여할 수 있는 팀이 없습니다.</div>
+                ) : (
+                    <>
                 <label className="block text-sm font-medium text-neutral-700 mb-1">참여할 팀 선택:</label>
                 <ItemListSelector
                     items={availableTeamsToJoin}
@@ -101,6 +243,8 @@ const TeamActionModal: React.FC<TeamActionModalProps> = ({ isOpen, onClose }) =>
                     renderItem={renderTeamItem}
                     itemKey="id"
                 />
+                    </>
+                )}
             </div>
         );
     }

--- a/components/modals/TeamCreateModal.tsx
+++ b/components/modals/TeamCreateModal.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { UserGroupIcon } from '@heroicons/react/24/outline';
+import { Modal, Button, Input } from '../ui';
+import { useAuth } from '../../AuthContext';
+import { teamApi } from '../../services/teamApi';
+
+interface TeamCreateModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onTeamCreated?: (team: any) => void; // 팀 생성 완료 시 콜백
+}
+
+const TeamCreateModal: React.FC<TeamCreateModalProps> = ({ isOpen, onClose, onTeamCreated }) => {
+    const [name, setName] = useState('');
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(false);
+    const { currentWorkspace } = useAuth();
+    const navigate = useNavigate();
+
+    const handleCloseAndReset = () => {
+        setName('');
+        setError('');
+        setLoading(false);
+        onClose();
+    };
+
+    const handleCreateTeam = async () => {
+        setError('');
+        
+        if (!name.trim()) {
+            setError('팀 이름을 입력해주세요.');
+            return;
+        }
+
+        if (!currentWorkspace) {
+            setError('워크스페이스 정보를 찾을 수 없습니다.');
+            return;
+        }
+
+        try {
+            setLoading(true);
+            
+            const newTeam = await teamApi.createTeam({
+                name: name.trim(),
+                workspaceId: currentWorkspace.id
+            });
+
+            // 팀 생성 성공 시 콜백 호출
+            if (onTeamCreated) {
+                onTeamCreated(newTeam);
+            }
+
+            // 생성된 팀 스페이스로 이동
+            navigate(`/ws/${currentWorkspace.id}/team/${newTeam.id}`);
+            handleCloseAndReset();
+        } catch (err: any) {
+            console.error('팀 생성 실패:', err);
+            setError(err.message || '팀 생성 중 오류가 발생했습니다.');
+        } finally {
+            setLoading(false);
+        }
+    };
+    
+    return (
+        <Modal 
+            isOpen={isOpen} 
+            onClose={handleCloseAndReset} 
+            title="새 팀 만들기"
+            footer={
+                <div className="flex justify-end space-x-2">
+                    <Button variant="ghost" onClick={handleCloseAndReset} disabled={loading}>취소</Button>
+                    <Button onClick={handleCreateTeam} disabled={loading}>
+                        {loading ? '생성 중...' : '팀 생성'}
+                    </Button>
+                </div>
+            }
+        >
+            <div className="space-y-4">
+                <p className="text-sm text-neutral-600">
+                    {currentWorkspace?.name} 워크스페이스에 새로운 팀을 만들어보세요.
+                </p>
+                <Input
+                    label="팀 이름"
+                    placeholder="예: 프론트엔드팀, 백엔드팀, 디자인팀"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    Icon={UserGroupIcon}
+                    disabled={loading}
+                    required
+                    maxLength={50}
+                />
+                <div className="text-xs text-neutral-500">
+                    <p>• 팀을 생성하면 자동으로 팀장이 됩니다.</p>
+                    <p>• 워크스페이스의 다른 멤버들을 팀에 초대할 수 있습니다.</p>
+                    <p>• 팀만의 칸반 보드, 게시판, 일정 관리를 사용할 수 있습니다.</p>
+                </div>
+                {error && <p className="text-sm text-red-500">{error}</p>}
+            </div>
+        </Modal>
+    );
+};
+
+export default TeamCreateModal; 

--- a/components/modals/index.ts
+++ b/components/modals/index.ts
@@ -3,4 +3,5 @@ export { default as JoinWorkspaceModal } from './JoinWorkspaceModal';
 export { default as NewChatModal } from './NewChatModal';
 export { default as NewVideoConferenceModal } from './NewVideoConferenceModal';
 export { default as TeamActionModal } from './TeamActionModal';
+export { default as TeamCreateModal } from './TeamCreateModal';
 export { default as WorkspaceSettingsModal } from './WorkspaceSettingsModal'; 

--- a/pages/TeamSpacePage.tsx
+++ b/pages/TeamSpacePage.tsx
@@ -3,7 +3,9 @@ import { useParams, useNavigate, Link, useLocation } from 'react-router-dom';
 import { Button, Input, Card, Modal, TextArea, VideoCameraIcon, CalendarDaysIcon, PlusCircleIcon, UserIcon, TrashIcon, XCircleIcon } from '../components'; // Removed ChatBubbleIcon
 import { TeamProject, Announcement, CalendarEvent, User, KanbanBoard, KanbanColumn, KanbanCard as KanbanCardType, KanbanComment, BulletinPost, BulletinComment } from '../types';
 import { useAuth } from '../AuthContext';
-import { PaperClipIcon, CheckCircleIcon, Bars3Icon, TableCellsIcon, ClipboardDocumentListIcon, ChevronLeftIcon, ChevronRightIcon, PencilIcon, ChatBubbleBottomCenterTextIcon } from '@heroicons/react/24/outline';
+import { PaperClipIcon, CheckCircleIcon, Bars3Icon, TableCellsIcon, ClipboardDocumentListIcon, ChevronLeftIcon, ChevronRightIcon, PencilIcon, ChatBubbleBottomCenterTextIcon, CogIcon, ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline';
+import { fetchKanbanBoard, addKanbanTaskComment, updateKanbanTask } from '../services/kanbanApi';
+import { teamApi } from '../services/teamApi';
 
 // Demo Team Data - 목업 데이터 제거, 실제 API만 사용
 const DEMO_TEAM_PROJECTS_ALL_DETAIL: TeamProject[] = [];
@@ -444,31 +446,33 @@ const TeamKanbanBoard: React.FC<{ teamProjectId: string, currentUser: User }> = 
 
 
     useEffect(() => {
-        const demoCommentsUser1: KanbanComment[] = [
-            { id: 'comment1-1', cardId: 'card1', userId: currentUser.id, userName: currentUser.name || '김코딩', text: '이거 오늘까지 마무리 가능할까요?', createdAt: new Date(Date.now() - 3600000) },
-            { id: 'comment1-2', cardId: 'card1', userId: 'otherUser', userName: '박해커', text: '네, 거의 다 됐습니다!', createdAt: new Date(Date.now() - 1800000) },
-        ];
-         const demoCommentsUser3: KanbanComment[] = [
-            { id: 'comment3-1', cardId: 'card3', userId: currentUser.id, userName: currentUser.name || '김코딩', text: 'OAuth 부분에서 이슈가 있는데 같이 봐주실 수 있나요?', createdAt: new Date(Date.now() - 7200000) },
-        ];
+        // TODO: 실제 API 연동 (현재는 목업 데이터 사용)
+        // const loadKanbanBoard = async () => {
+        //     try {
+        //         const kanbanBoard = await fetchKanbanBoard(teamProjectId);
+        //         setBoard(kanbanBoard);
+        //     } catch (error) {
+        //         console.error('Failed to load kanban board:', error);
+        //     }
+        // };
+        // loadKanbanBoard();
 
+        // 임시 목업 데이터 (API 연동 후 제거 예정)
         const demoCards: KanbanCardType[] = [
-            {id: 'card1', title: '로그인 페이지 디자인', description: '사용자 인증 UI 구현', columnId: 'col1', order: 0, assigneeIds: [currentUser.id], comments: demoCommentsUser1, dueDate: new Date(Date.now() + 2 * 86400000)},
-            {id: 'card2', title: 'API 문서 작성', description: 'REST API 명세서 작성', columnId: 'col2', order: 0, assigneeIds: ['backend_dev_id'], dueDate: new Date(Date.now() + 5 * 86400000), comments: demoCommentsUser3, assigneeIds: [currentUser.id, 'backend_dev_id']},
-            {id: 'card3', columnId: 'col2', title: '로그인 기능 개발', description: 'OAuth 2.0 (Google, Kakao) 연동 및 자체 이메일/비밀번호 로그인 기능 구현. JWT 토큰 기반 인증.', order: 0, dueDate: new Date(Date.now() + 5 * 86400000), comments: demoCommentsUser3, assigneeIds: [currentUser.id, 'backend_dev_id']},
-            {id: 'card4', columnId: 'col3', title: '1차 QA 완료', description: '회원가입 및 로그인 플로우, 기본 팀 생성 기능에 대한 QA 완료됨.', order: 0, isApproved: true},
-            {id: 'card5', columnId: 'col3', title: '팀 공지사항 UI 개발', description: '팀 스페이스 내 공지사항 CRUD UI 개발 완료.', order: 1, isApproved: false},
+            {id: 'card1', title: '로그인 페이지 디자인', description: '사용자 인증 UI 구현', columnId: 'col1', order: 0, assigneeIds: [currentUser.id], dueDate: new Date(Date.now() + 2 * 86400000)},
+            {id: 'card2', title: 'API 문서 작성', description: 'REST API 명세서 작성', columnId: 'col2', order: 0, assigneeIds: [currentUser.id], dueDate: new Date(Date.now() + 5 * 86400000)},
+            {id: 'card3', columnId: 'col3', title: '1차 QA 완료', description: '회원가입 및 로그인 플로우 QA 완료.', order: 0, isApproved: true},
         ];
         setBoard({
             id: `kanban-${teamProjectId}`,
             teamProjectId,
             columns: [
-                {id: 'col1', boardId: `kanban-${teamProjectId}`, title: 'To Do', cards: demoCards.filter(c => c.columnId === 'col1').sort((a,b) => a.order - b.order), order: 0},
-                {id: 'col2', boardId: `kanban-${teamProjectId}`, title: 'In Progress', cards: demoCards.filter(c => c.columnId === 'col2').sort((a,b) => a.order - b.order), order: 1},
-                {id: 'col3', boardId: `kanban-${teamProjectId}`, title: 'Done', cards: demoCards.filter(c => c.columnId === 'col3').sort((a,b) => a.order - b.order), order: 2},
+                {id: 'col1', boardId: `kanban-${teamProjectId}`, title: 'To Do', cards: demoCards.filter(c => c.columnId === 'col1'), order: 0},
+                {id: 'col2', boardId: `kanban-${teamProjectId}`, title: 'In Progress', cards: demoCards.filter(c => c.columnId === 'col2'), order: 1},
+                {id: 'col3', boardId: `kanban-${teamProjectId}`, title: 'Done', cards: demoCards.filter(c => c.columnId === 'col3'), order: 2},
             ]
         });
-    }, [teamProjectId, currentUser.id, currentUser.name]);
+    }, [teamProjectId]);
 
     const handleCardClick = (card: KanbanCardType, columnTitle: string) => {
         setSelectedCard(card);
@@ -848,9 +852,16 @@ export const TeamSpacePage: React.FC = () => {
   
   const [team, setTeam] = useState<TeamProject | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>('');
   const [password, setPassword] = useState(''); 
   const [authError, setAuthError] = useState('');
   const [isAuthenticatedForTeam, setIsAuthenticatedForTeam] = useState(false);
+  
+  // 팀 설정 관련 상태
+  const [showTeamSettingsDropdown, setShowTeamSettingsDropdown] = useState(false);
+  const [showLeaveTeamModal, setShowLeaveTeamModal] = useState(false);
+  const [showDeleteTeamModal, setShowDeleteTeamModal] = useState(false);
+  const [teamActionLoading, setTeamActionLoading] = useState(false);
   
   const TABS = [
       { name: '공지', id: 'announcements', icon: <ClipboardDocumentListIcon /> },
@@ -882,35 +893,7 @@ export const TeamSpacePage: React.FC = () => {
   }, [location.search, activeTab]);
 
 
-  useEffect(() => {
-    if (teamProjectId) {
-      if (currentTeamProject && currentTeamProject.id === teamProjectId) {
-        setTeam(currentTeamProject);
-        if (!currentTeamProject.passwordProtected) setIsAuthenticatedForTeam(true);
-        setLoading(false);
-      } else {
-        setLoading(true);
-        setTimeout(() => { 
-          const foundTeam = DEMO_TEAM_PROJECTS_ALL_DETAIL.find(t => t.id === teamProjectId && t.workspaceId === workspaceId);
-          if (foundTeam) {
-            setTeam(foundTeam);
-            setCurrentTeamProject(foundTeam); 
-            if (!foundTeam.passwordProtected) {
-              setIsAuthenticatedForTeam(true);
-            } else {
-              setIsAuthenticatedForTeam(false); 
-            }
-          } else {
-            setTeam(null); 
-          }
-          setLoading(false);
-        }, 300);
-      }
-    } else {
-        setTeam(null);
-        setLoading(false);
-    }
-  }, [workspaceId, teamProjectId, currentTeamProject, setCurrentTeamProject]);
+  // 기존의 데모 데이터 사용 로직 제거 - 실제 API 호출로 대체됨
 
 
   const handlePasswordSubmit = () => {
@@ -945,7 +928,118 @@ export const TeamSpacePage: React.FC = () => {
     }
   }, [team, setCurrentTeamProject]);
 
+  // 팀 탈퇴 기능
+  const handleLeaveTeam = useCallback(async () => {
+    if (!team || !teamProjectId) return;
+    
+    try {
+      setTeamActionLoading(true);
+      await teamApi.leaveTeam(teamProjectId);
+      setShowLeaveTeamModal(false);
+      // 팀 탈퇴 성공 시 워크스페이스 홈으로 이동
+      navigate(`/ws/${workspaceId}`);
+    } catch (error) {
+      console.error('팀 탈퇴 실패:', error);
+      alert('팀 탈퇴에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setTeamActionLoading(false);
+    }
+  }, [team, teamProjectId, workspaceId, navigate]);
+
+  // 팀 삭제 기능
+  const handleDeleteTeam = useCallback(async () => {
+    if (!team || !teamProjectId) return;
+    
+    try {
+      setTeamActionLoading(true);
+      await teamApi.deleteTeam(teamProjectId);
+      setShowDeleteTeamModal(false);
+      // 팀 삭제 성공 시 워크스페이스 홈으로 이동
+      navigate(`/ws/${workspaceId}`);
+    } catch (error) {
+      console.error('팀 삭제 실패:', error);
+      alert('팀 삭제에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setTeamActionLoading(false);
+    }
+  }, [team, teamProjectId, workspaceId, navigate]);
+
+  // 현재 사용자가 팀장인지 확인하는 함수
+  const isTeamLeader = useCallback(() => {
+    if (!team || !currentUser) {
+      console.log('팀장 권한 확인 실패: team 또는 currentUser 없음');
+      return false;
+    }
+    
+    // 임시로 모든 팀 멤버가 팀장 권한을 가지도록 설정 (테스트용)
+    const hasLeaderPermission = team.members.some(member => member.id === currentUser.id);
+    console.log('팀장 권한 확인:', { 
+      currentUserId: currentUser.id, 
+      teamMembers: team.members.map(m => m.id), 
+      hasLeaderPermission 
+    });
+    
+    // 테스트용: 팀 멤버라면 팀장 권한 부여
+    return hasLeaderPermission;
+  }, [team, currentUser]);
+
+  // 팀 데이터 로드 함수
+  const loadTeamData = async () => {
+    console.log('팀 데이터 로드 시작:', teamProjectId);
+    
+    if (!teamProjectId) {
+      console.log('팀 ID 없음');
+      setTeam(null);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError('');
+      
+      // 실제 API 호출 - 백엔드에서 이미 멤버 정보도 함께 반환함
+      const teamData = await teamApi.getTeam(teamProjectId);
+      console.log('팀 데이터 로드 성공:', teamData);
+      
+      setTeam(teamData);
+      setCurrentTeamProject(teamData);
+      
+      // 비밀번호 보호가 없다면 바로 인증 완료
+      if (!teamData.passwordProtected) {
+        setIsAuthenticatedForTeam(true);
+      }
+    } catch (error) {
+      console.error('팀 데이터 로드 실패:', error);
+      setError('팀 정보를 불러오는데 실패했습니다.');
+      setTeam(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTeamData();
+  }, [workspaceId, teamProjectId]);
+
+  // 드롭다운 외부 클릭 시 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (showTeamSettingsDropdown) {
+        const target = event.target as Element;
+        // 드롭다운 내부나 톱니바퀴 버튼 클릭이 아닌 경우만 닫기
+        if (!target.closest('[data-dropdown="team-settings"]')) {
+          setShowTeamSettingsDropdown(false);
+        }
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showTeamSettingsDropdown]);
+
   if (loading) return <div className="p-6 text-center">팀 정보를 불러오는 중...</div>;
+  if (error) return <div className="p-6 text-center text-red-500">{error}</div>;
   if (!team) return <div className="p-6 text-center text-red-500">팀을 찾을 수 없습니다. <Link to={`/ws/${workspaceId || ''}`} className="text-primary hover:underline">워크스페이스 홈으로</Link></div>;
   if (!currentUser) return <p className="p-6">로그인이 필요합니다.</p>; 
 
@@ -984,7 +1078,60 @@ export const TeamSpacePage: React.FC = () => {
   return (
     <div className="space-y-6">
       <Card title={`팀 스페이스: ${team.name}`} 
-            actions={team.progress !== undefined ? <span className="text-sm text-neutral-500">진행도: {team.progress}%</span> : null}>
+            actions={
+              <div className="flex items-center space-x-4">
+                {team.progress !== undefined && (
+                  <span className="text-sm text-neutral-500">진행도: {team.progress}%</span>
+                )}
+                {/* 팀 설정 드롭다운 */}
+                <div className="relative" data-dropdown="team-settings">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowTeamSettingsDropdown(!showTeamSettingsDropdown)}
+                    className="p-1"
+                    data-dropdown="team-settings"
+                  >
+                    <CogIcon className="w-5 h-5" />
+                  </Button>
+                  
+                  {showTeamSettingsDropdown && (
+                    <div 
+                      className="absolute right-0 mt-2 w-48 bg-white border border-neutral-200 rounded-md shadow-lg z-20"
+                      data-dropdown="team-settings"
+                    >
+                      <div className="py-1" data-dropdown="team-settings">
+                        <button
+                          onClick={() => {
+                            setShowTeamSettingsDropdown(false);
+                            setShowLeaveTeamModal(true);
+                          }}
+                          className="w-full px-4 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-100 flex items-center space-x-2"
+                          data-dropdown="team-settings"
+                        >
+                          <ArrowRightOnRectangleIcon className="w-4 h-4" />
+                          <span>팀 탈퇴</span>
+                        </button>
+                        
+                        {isTeamLeader() && (
+                          <button
+                            onClick={() => {
+                              setShowTeamSettingsDropdown(false);
+                              setShowDeleteTeamModal(true);
+                            }}
+                            className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 flex items-center space-x-2"
+                            data-dropdown="team-settings"
+                          >
+                            <TrashIcon className="w-4 h-4" />
+                            <span>팀 삭제</span>
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            }>
         <div className="mb-6 border-b border-neutral-200">
           <nav className="-mb-px flex space-x-1 sm:space-x-2 overflow-x-auto" aria-label="Tabs">
             {TABS.map((tab) => (
@@ -1004,6 +1151,101 @@ export const TeamSpacePage: React.FC = () => {
         </div>
         {contentToRender}
       </Card>
+      
+      {/* 팀 탈퇴 확인 모달 */}
+      <Modal
+        isOpen={showLeaveTeamModal}
+        onClose={() => setShowLeaveTeamModal(false)}
+        title="팀 탈퇴 확인"
+        footer={
+          <div className="flex justify-end space-x-2">
+            <Button 
+              variant="ghost" 
+              onClick={() => setShowLeaveTeamModal(false)}
+              disabled={teamActionLoading}
+            >
+              취소
+            </Button>
+            <Button 
+              variant="danger" 
+              onClick={handleLeaveTeam}
+              disabled={teamActionLoading}
+            >
+              {teamActionLoading ? '처리 중...' : '탈퇴하기'}
+            </Button>
+          </div>
+        }
+      >
+        <div className="space-y-4">
+          <div className="flex items-center space-x-3">
+            <div className="flex-shrink-0">
+              <ArrowRightOnRectangleIcon className="w-8 h-8 text-orange-500" />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-neutral-900">
+                정말로 팀을 탈퇴하시겠습니까?
+              </h3>
+              <p className="text-sm text-neutral-500">
+                팀 탈퇴 시 다시 팀에 참여하려면 팀 초대를 받아야 합니다.
+              </p>
+            </div>
+          </div>
+          <div className="bg-orange-50 border border-orange-200 rounded-md p-4">
+            <p className="text-sm text-orange-700">
+              ⚠️ 팀 탈퇴 후에는 다시 팀에 참여하려면 팀 가입을 다시 해야 합니다.
+            </p>
+          </div>
+        </div>
+      </Modal>
+      
+      {/* 팀 삭제 확인 모달 */}
+      <Modal
+        isOpen={showDeleteTeamModal}
+        onClose={() => setShowDeleteTeamModal(false)}
+        title="팀 삭제 확인"
+        footer={
+          <div className="flex justify-end space-x-2">
+            <Button 
+              variant="ghost" 
+              onClick={() => setShowDeleteTeamModal(false)}
+              disabled={teamActionLoading}
+            >
+              취소
+            </Button>
+            <Button 
+              variant="danger" 
+              onClick={() => {
+                console.log('삭제하기 버튼 클릭됨');
+                handleDeleteTeam();
+              }}
+              disabled={teamActionLoading}
+            >
+              {teamActionLoading ? '처리 중...' : '삭제하기'}
+            </Button>
+          </div>
+        }
+      >
+        <div className="space-y-4">
+          <div className="flex items-center space-x-3">
+            <div className="flex-shrink-0">
+              <TrashIcon className="w-8 h-8 text-red-500" />
+            </div>
+            <div>
+              <h3 className="text-lg font-medium text-neutral-900">
+                정말로 팀을 삭제하시겠습니까?
+              </h3>
+              <p className="text-sm text-neutral-500">
+                팀 삭제는 되돌릴 수 없으며, 모든 데이터가 영구적으로 삭제됩니다.
+              </p>
+            </div>
+          </div>
+          <div className="bg-red-50 border border-red-200 rounded-md p-4">
+            <p className="text-sm text-red-700">
+              🚨 <strong>주의:</strong> 팀의 모든 칸반 보드, 게시글, 일정, 공지사항이 삭제됩니다.
+            </p>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/services/api.ts
+++ b/services/api.ts
@@ -27,7 +27,7 @@ class ApiError extends Error {
 }
 
 // HTTP 요청 래퍼 함수
-async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+export async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
   const token = tokenManager.getAccessToken();
   
@@ -402,4 +402,7 @@ export const userApi = {
   },
 };
 
-export { ApiError }; 
+export { ApiError };
+
+// 다른 API 서비스들도 함께 export
+export { teamApi } from './teamApi'; 

--- a/services/kanbanApi.ts
+++ b/services/kanbanApi.ts
@@ -1,0 +1,201 @@
+import { KanbanBoard, KanbanCard, KanbanColumn, KanbanComment } from '../types';
+
+const API_BASE_URL = '/api/kanban';
+
+// 칸반 보드 조회
+export const fetchKanbanBoard = async (teamId: string): Promise<KanbanBoard> => {
+  const response = await fetch(`${API_BASE_URL}/team/${teamId}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch kanban board');
+  }
+
+  const result = await response.json();
+  
+  // 백엔드 응답을 프론트엔드 타입에 맞게 변환
+  const kanbanData = result.data;
+  return {
+    id: kanbanData.id.toString(),
+    teamProjectId: teamId,
+    columns: kanbanData.kanbanLists.map((list: any, index: number) => ({
+      id: list.id.toString(),
+      boardId: kanbanData.id.toString(),
+      title: list.kanbanListName,
+      order: index,
+      cards: list.tasks.map((task: any) => ({
+        id: task.id.toString(),
+        columnId: list.id.toString(),
+        title: task.subject,
+        description: task.content,
+        order: task.order || 0,
+        isApproved: task.isApproved,
+        dueDate: task.deadline ? new Date(task.deadline) : undefined,
+        assigneeIds: task.members?.map((member: any) => member.accountId.toString()) || [],
+        comments: task.comments?.map((comment: any) => ({
+          id: comment.id.toString(),
+          cardId: task.id.toString(),
+          userId: comment.accountId.toString(),
+          userName: comment.authorName,
+          text: comment.comment,
+          createdAt: new Date(comment.createdAt),
+        })) || [],
+        attachments: task.attachments?.map((attach: any) => ({
+          id: attach.id.toString(),
+          cardId: task.id.toString(),
+          fileName: attach.fileName,
+          fileUrl: attach.fileUrl,
+          uploadedAt: new Date(attach.uploadedAt),
+          uploaderId: 'unknown',
+        })) || [],
+      })),
+    })),
+  };
+};
+
+// 새 태스크 생성
+export const createKanbanTask = async (taskData: {
+  subject: string;
+  content?: string;
+  kanbanListId: string;
+  deadline?: Date;
+  assigneeIds?: string[];
+}): Promise<KanbanCard> => {
+  const response = await fetch(`${API_BASE_URL}/tasks`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      subject: taskData.subject,
+      content: taskData.content,
+      kanbanListId: parseInt(taskData.kanbanListId),
+      deadline: taskData.deadline?.toISOString(),
+      assigneeIds: taskData.assigneeIds?.map(id => parseInt(id)),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to create kanban task');
+  }
+
+  const result = await response.json();
+  const task = result.data;
+  
+  return {
+    id: task.id.toString(),
+    columnId: task.kanbanListId.toString(),
+    title: task.subject,
+    description: task.content,
+    order: task.order || 0,
+    isApproved: task.isApproved,
+    dueDate: task.deadline ? new Date(task.deadline) : undefined,
+    assigneeIds: task.members?.map((member: any) => member.accountId.toString()) || [],
+    comments: task.comments || [],
+    attachments: task.attachments || [],
+  };
+};
+
+// 태스크 업데이트
+export const updateKanbanTask = async (taskId: string, taskData: {
+  subject?: string;
+  content?: string;
+  kanbanListId?: string;
+  deadline?: Date;
+  isApproved?: boolean;
+  assigneeIds?: string[];
+}): Promise<KanbanCard> => {
+  const response = await fetch(`${API_BASE_URL}/tasks/${taskId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      subject: taskData.subject,
+      content: taskData.content,
+      kanbanListId: taskData.kanbanListId ? parseInt(taskData.kanbanListId) : undefined,
+      deadline: taskData.deadline?.toISOString(),
+      isApproved: taskData.isApproved,
+      assigneeIds: taskData.assigneeIds?.map(id => parseInt(id)),
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to update kanban task');
+  }
+
+  const result = await response.json();
+  const task = result.data;
+  
+  return {
+    id: task.id.toString(),
+    columnId: task.kanbanListId.toString(),
+    title: task.subject,
+    description: task.content,
+    order: task.order || 0,
+    isApproved: task.isApproved,
+    dueDate: task.deadline ? new Date(task.deadline) : undefined,
+    assigneeIds: task.members?.map((member: any) => member.accountId.toString()) || [],
+    comments: task.comments?.map((comment: any) => ({
+      id: comment.id.toString(),
+      cardId: task.id.toString(),
+      userId: comment.accountId.toString(),
+      userName: comment.authorName,
+      text: comment.comment,
+      createdAt: new Date(comment.createdAt),
+    })) || [],
+    attachments: task.attachments || [],
+  };
+};
+
+// 댓글 추가
+export const addKanbanTaskComment = async (taskId: string, comment: string): Promise<KanbanComment> => {
+  const response = await fetch(`${API_BASE_URL}/tasks/${taskId}/comments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      comment: comment,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to add comment');
+  }
+
+  const result = await response.json();
+  const commentData = result.data;
+  
+  return {
+    id: commentData.id.toString(),
+    cardId: commentData.kanbanTaskId.toString(),
+    userId: commentData.accountId.toString(),
+    userName: commentData.authorName,
+    text: commentData.comment,
+    createdAt: new Date(commentData.createdAt),
+  };
+};
+
+// 태스크 삭제
+export const deleteKanbanTask = async (taskId: string): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/tasks/${taskId}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete kanban task');
+  }
+}; 

--- a/services/teamApi.ts
+++ b/services/teamApi.ts
@@ -1,0 +1,178 @@
+import { TeamProject, User } from '../types';
+import { apiRequest, ApiError } from './api';
+
+// 팀 응답 데이터 변환 헬퍼 함수
+const transformTeamResponse = (team: { 
+  id: number; 
+  workspaceId: number; 
+  name: string; 
+  members?: any[]; 
+  memberCount?: number; 
+}): TeamProject => {
+  return {
+    id: team.id.toString(),
+    workspaceId: team.workspaceId.toString(),
+    name: team.name,
+    members: team.members ? team.members.map((member: any) => ({
+      id: member.accountId.toString(), // accountId를 사용
+      email: member.email,
+      name: member.name,
+      profileImage: member.profileImage,
+      profilePictureUrl: member.profileImage || `https://picsum.photos/seed/${member.email}/100/100`,
+      tags: [], // TeamMemberResponse에는 tags가 없으므로 빈 배열
+      age: member.age,
+      mbti: member.mbti,
+      disposition: member.disposition,
+      introduction: member.introduction,
+      portfolio: member.portfolio,
+      preferWorkstyle: member.preferWorkstyle,
+      dislikeWorkstyle: member.dislikeWorkstyle,
+      likes: member.likes,
+      dislikes: member.dislikes,
+      bio: member.introduction,
+      portfolioLink: member.portfolio,
+      preferredStyle: member.preferWorkstyle,
+      avoidedStyle: member.dislikeWorkstyle,
+    })) : [],
+    memberCount: team.memberCount || 0,
+    announcements: [],
+    passwordProtected: false,
+    progress: 0,
+  };
+};
+
+// 팀 멤버 응답 데이터 변환 헬퍼 함수
+const transformTeamMemberResponse = (member: {
+  id: number;
+  email: string;
+  name: string;
+  age?: number;
+  mbti?: string;
+  disposition?: string;
+  introduction?: string;
+  portfolio?: string;
+  preferWorkstyle?: string;
+  dislikeWorkstyle?: string;
+  likes?: string;
+  dislikes?: string;
+  profileImage?: string;
+  tags?: string[];
+}): User => {
+  return {
+    id: member.id.toString(),
+    email: member.email,
+    name: member.name,
+    age: member.age,
+    mbti: member.mbti,
+    disposition: member.disposition,
+    introduction: member.introduction,
+    portfolio: member.portfolio,
+    preferWorkstyle: member.preferWorkstyle,
+    dislikeWorkstyle: member.dislikeWorkstyle,
+    likes: member.likes,
+    dislikes: member.dislikes,
+    profileImage: member.profileImage,
+    tags: member.tags || [],
+    bio: member.introduction,
+    portfolioLink: member.portfolio,
+    preferredStyle: member.preferWorkstyle,
+    avoidedStyle: member.dislikeWorkstyle,
+    profilePictureUrl: member.profileImage || `https://picsum.photos/seed/${member.email}/100/100`,
+  };
+};
+
+export const teamApi = {
+  // 워크스페이스의 팀 목록 조회
+  getTeamsByWorkspace: async (workspaceId: string): Promise<TeamProject[]> => {
+    const response = await apiRequest<{success: boolean; message: string; data: any[]}>(`/teams/workspace/${workspaceId}`);
+    
+    if (response.success && response.data) {
+      return response.data.map(team => transformTeamResponse(team));
+    }
+    
+    throw new ApiError(400, response.message || '팀 목록 조회에 실패했습니다.');
+  },
+
+  // 팀 상세 조회
+  getTeam: async (teamId: string): Promise<TeamProject> => {
+    const response = await apiRequest<{success: boolean; message: string; data: any}>(`/teams/${teamId}`);
+    
+    if (response.success && response.data) {
+      return transformTeamResponse(response.data);
+    }
+    
+    throw new ApiError(400, response.message || '팀 조회에 실패했습니다.');
+  },
+
+  // 팀 생성
+  createTeam: async (data: { name: string; workspaceId: string }): Promise<TeamProject> => {
+    const response = await apiRequest<{success: boolean; message: string; data: any}>('/teams', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+    
+    if (response.success && response.data) {
+      return transformTeamResponse(response.data);
+    }
+    
+    throw new ApiError(400, response.message || '팀 생성에 실패했습니다.');
+  },
+
+  // 팀 수정
+  updateTeam: async (teamId: string, data: { name?: string }): Promise<TeamProject> => {
+    const response = await apiRequest<{success: boolean; message: string; data: any}>(`/teams/${teamId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    });
+    
+    if (response.success && response.data) {
+      return transformTeamResponse(response.data);
+    }
+    
+    throw new ApiError(400, response.message || '팀 수정에 실패했습니다.');
+  },
+
+  // 팀 삭제
+  deleteTeam: async (teamId: string): Promise<void> => {
+    const response = await apiRequest<{success: boolean; message: string; data: null}>(`/teams/${teamId}`, {
+      method: 'DELETE',
+    });
+    
+    if (!response.success) {
+      throw new ApiError(400, response.message || '팀 삭제에 실패했습니다.');
+    }
+  },
+
+  // 팀 참여
+  joinTeam: async (teamId: string): Promise<void> => {
+    const response = await apiRequest<{success: boolean; message: string; data: null}>(`/teams/${teamId}/join`, {
+      method: 'POST',
+    });
+    
+    if (!response.success) {
+      throw new ApiError(400, response.message || '팀 참여에 실패했습니다.');
+    }
+  },
+
+  // 팀 탈퇴
+  leaveTeam: async (teamId: string): Promise<void> => {
+    const response = await apiRequest<{success: boolean; message: string; data: null}>(`/teams/${teamId}/leave`, {
+      method: 'POST',
+    });
+    
+    if (!response.success) {
+      throw new ApiError(400, response.message || '팀 탈퇴에 실패했습니다.');
+    }
+  },
+
+  // 팀 멤버 목록 조회
+  getTeamMembers: async (teamId: string): Promise<User[]> => {
+    const response = await apiRequest<{success: boolean; message: string; data: any[]}>(`/teams/${teamId}/members`);
+    
+    if (response.success && response.data) {
+      return response.data.map(member => transformTeamMemberResponse(member));
+    }
+    
+    throw new ApiError(400, response.message || '팀 멤버 조회에 실패했습니다.');
+  },
+}; 


### PR DESCRIPTION
팀 스페이스 crud 기능 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 워크스페이스별 팀 목록을 실시간으로 불러오고 표시하는 기능이 추가되었습니다.
  * 팀 생성 및 기존 팀 참여를 위한 모달이 도입되어, 팀 관리가 더욱 편리해졌습니다.
  * 팀 상세 페이지에서 팀 탈퇴 및 삭제 기능과 확인 모달이 추가되었습니다.
  * 칸반 보드 API 연동이 시작되어, 팀별 칸반 데이터 조회 및 작업 관리가 가능합니다.

* **버그 수정**
  * 팀 생성, 참여, 탈퇴, 삭제 시 발생할 수 있는 오류에 대한 처리와 사용자 안내가 개선되었습니다.

* **UI/UX 개선**
  * 권한에 따라 워크스페이스 설정 내 탭 및 위험 구역 접근이 제한됩니다.
  * 팀 목록, 생성/참여 버튼, 로딩 및 에러 상태 표시 등 팀 관련 UI가 전반적으로 개선되었습니다.
  * 워크스페이스 영구 삭제 시 경고와 확인 절차가 명확해졌습니다.

* **기타**
  * 팀 및 칸반 관련 API 서비스가 추가되어, 실데이터 기반의 팀/프로젝트 관리가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->