### PR TITLE
5차 버그 수정 (워크스페이스 관리자가 아닌 일반사용자가 화상회의 채널 삭제 버튼이 뜨는 현상)

### DIFF
--- a/src/features/teamspace/core/components/TeamProjectSidebar.tsx
+++ b/src/features/teamspace/core/components/TeamProjectSidebar.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate, useParams, useLocation } from 'react-router-dom';
+import { workspaceApi } from '../../../workspace/management/api/workspaceApi';
+import { Workspace } from '../../../workspace/types/workspace';
 import { useWorkspace } from '@/features/workspace/core/hooks/useWorkspace';
 import { useAuth } from '@/features/user/auth/hooks/useAuth';
 import { teamApi } from '@/features/teamspace/team/api/teamApi';
@@ -38,6 +40,8 @@ export const TeamProjectSidebar: React.FC = () => {
     const [isNewChatModalOpen, setIsNewChatModalOpen] = useState(false);
     const [isNewVideoConferenceModalOpen, setIsNewVideoConferenceModalOpen] = useState(false);
     const [isWorkspaceSettingsModalOpen, setIsWorkspaceSettingsModalOpen] = useState(false);
+    const [canDeleteRoom,setCanDeleteRoom] = useState<boolean>(false);
+
 
     // 팀 목록 로드
     useEffect(() => {
@@ -123,6 +127,17 @@ export const TeamProjectSidebar: React.FC = () => {
 
         loadChatRooms();
     }, [currentWorkspace, currentUser]);
+
+
+    useEffect(()=>{
+        (async()=>{
+        const  workspace:Workspace = await workspaceApi.getWorkspaceDetails(currentWorkspace?.id!);
+            if(workspace.owner.id === parseInt(currentUser?.id!)){
+                setCanDeleteRoom(true); 
+            }
+        })();
+    },[currentWorkspace, currentUser]);
+
 
     const handleTeamCreated = (newTeam: Team) => {
         setTeamProjects(prev => [...prev, newTeam]);
@@ -396,7 +411,7 @@ export const TeamProjectSidebar: React.FC = () => {
                                         <VideoCameraIcon className="h-4 w-4 text-neutral-500" />
                                         <span className="truncate">{channel.name}</span>
                                     </Link>
-                                    <button
+                                    {canDeleteRoom && <button
                                         onClick={(e) => {
                                             e.preventDefault();
                                             handleDeleteVideoChannel(channel.id, channel.name);
@@ -405,7 +420,7 @@ export const TeamProjectSidebar: React.FC = () => {
                                         title="화상회의 방 삭제"
                                     >
                                         <TrashIcon className="h-4 w-4" />
-                                    </button>
+                                    </button>}
                                 </div>
                             </li>
                         ))}


### PR DESCRIPTION
5차 버그 수정 (워크스페이스 관리자가 아닌 일반사용자가 화상회의 채널 삭제 버튼이 뜨는 현상)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 워크스페이스 소유자만 화상 회의실 삭제 버튼을 볼 수 있도록 권한이 추가되었습니다.  
* **버그 수정**
  * 삭제 버튼이 잘못 표시되는 문제를 해결하여, 이제 소유자만 삭제할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->